### PR TITLE
DOC: Fix name of requirements.txt file and link to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ python generalization.py
 
 
 ###### <h3> Requirement 
-The requirements file used to run experiments is available in the requirement.txt.
+The requirements used to run the experiments are available in the [requirements.txt](requirements.txt) file.
   
 
 ###### <h3> Copyright and License 


### PR DESCRIPTION
Change the filename referred to from requirement.txt (no s) to requirements.txt (with s), and add a relative link to the file.